### PR TITLE
Allow png parameters to Linux launcher file, enabling "Open With"

### DIFF
--- a/genlinux/setup_linux.py
+++ b/genlinux/setup_linux.py
@@ -359,12 +359,13 @@ class Data:
             file.write("Name=%s\n" % _("Lucas Chess"))
             # file.write("GenericName=%s\n")
             # file.write("Comment=%s\n")
-            file.write("Exec=" + launcher + "\n")
+            file.write("Exec=" + launcher + " %F\n")
             file.write("Path=" + path + "\n")
             file.write("Icon=" + icon + "\n")
             file.write("StartupNotify=true\n")
             file.write("Terminal=false\n")
-            file.write("Categories=Game;")
+            file.write("Categories=Game;\n")
+            file.write("MimeType=application/vnd.chess-pgn\n")
         os.chmod(self.path_desktop, self.access_rights)
 
     def launch_lucasr(self):


### PR DESCRIPTION
This tweaks the generation of the linux launcher file, typically found in `~/.local/share/applications/LucasChessR.desktop`:

- Add ` %F` to the end of `Exec=`, opening the possibility to pass multiple files, which makes Lucas Chess displayed in "Open With" dialogs in the file browser.
- Add `MimeType=application/vnd.chess-pgn` line, indicating the type of file lucas chess wants to consume

Open questions:
- Should we add any other file types that Lucas Chess can already handle?
- There seems to be a bug in Lucas Chess 2.04 on Linux handling multiple passed file: If I pass two pngs only one of them is opened. I put `%F` anyhow, as `%f` would launch lucaschess multiple times (once for each file), which is probably not what the user wants.
