### PR TITLE
Enable fastercode to be compiled on aarch64

### DIFF
--- a/bin/_fastercode/source/irina/util.c
+++ b/bin/_fastercode/source/irina/util.c
@@ -19,7 +19,7 @@ int is_bmi2()
 int is_bmi2()
 {
     #ifdef __aarch64__
-    return O;
+    return 0;
     #else
     __builtin_cpu_init ();
     return __builtin_cpu_supports("bmi2");

--- a/bin/_fastercode/source/irina/util.c
+++ b/bin/_fastercode/source/irina/util.c
@@ -18,8 +18,12 @@ int is_bmi2()
 #include <stdint.h>
 int is_bmi2()
 {
+    #ifdef __aarch64__
+    return O;
+    #else
     __builtin_cpu_init ();
     return __builtin_cpu_supports("bmi2");
+    #endif
 }
 #endif
 


### PR DESCRIPTION
Checking the architecture and avoid bmi2 to be mandatory on arm architectures