### PR TITLE
Getting quickly started on Linux + Fixing Tutor issue when using the Vanilla github version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Lucas Chess (R)
 ==============
-
 Lucas Chess (R) is a GUI of chess:
 
 1. To train in many different ways.
@@ -10,7 +9,6 @@ Lucas Chess (R) is a GUI of chess:
 
 This is an update of Lucas Chess with a new version of python (2.7 -> 3.7) and the main graphic library, from pyqt4 to pyside2 (qt4 -> qt5).
 
-
 Incompatibilities
 -----------------
 * **Does not support Windows XP.**
@@ -18,8 +16,7 @@ Incompatibilities
 
 Dependencies
 ------------
-
-* Python 3.7
+* Python 3.7 or later
 * PySide2
 * psutil
 * Python for windows extensions
@@ -31,10 +28,14 @@ Dependencies
 * sortedcontainers
 * polib
 
+Getting quickly started on Linux
+--------------------------------
+1. clone this repository on your local machine and cd into the LucasChessR2 folder
+2. type `bash linux_onetime_setup.sh`
+3. then `cd bin && python3 LucasR.py`
 
 Links
 -----
-
 * Web: [https://lucaschess.pythonanywhere.com/](https://lucaschess.pythonanywhere.com/).
 * Blog: [https://lucaschess.blogspot.com.es/](https://lucaschess.blogspot.com.es/).
 * Wiki: [https://chessionate.com/lucaswiki](https://chessionate.com/lucaswiki/).
@@ -42,7 +43,6 @@ Links
 
 Legal Details
 -------------
-
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or (at

--- a/bin/bug.log
+++ b/bin/bug.log
@@ -1,1 +1,0 @@
-Version R 2.10

--- a/linux_onetime_setup.sh
+++ b/linux_onetime_setup.sh
@@ -8,4 +8,3 @@ FILE=nn-5af11540bbfe.nnue
 if [ ! -f "$FILE" ]; then
     wget https://tests.stockfishchess.org/api/nn/nn-5af11540bbfe.nnue
 fi
-

--- a/linux_onetime_setup.sh
+++ b/linux_onetime_setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+cd bin/_fastercode
+bash linux64.sh
+cd ../OS/linux/
+bash RunEngines
+cd Engines/stockfish/
+FILE=nn-5af11540bbfe.nnue
+if [ ! -f "$FILE" ]; then
+    wget https://tests.stockfishchess.org/api/nn/nn-5af11540bbfe.nnue
+fi
+


### PR DESCRIPTION
After cloning the 2.10 repository, and to get LucasChess quickly started on my Linux machine, I wrote the linux_onetime_setup.sh script. The script performs the fastercode compile + gives exec rights of the engines by executing RunEngines + fixes a bug that I have not found where to fix in the Python code  (which you may want to have a look at : in absence of stockfish nnue file, and despite writing 'Use NNUE' to false in the *.uci_options files of the stockfish folder, the Tutor (when using stockfish) simply does not work. Also playing against stockfish as an opponent also does not work, even when changing the Use NNUE to false uci option directly in LucasChess. This gets resolved by downloading the nnue file where stockfish looks for it, step which I added to the one-time script above.)
I've also added few lines on the Readme file as it tells how to get quickly started from the github repo (it took me a good hour the first time I cloned the repo to get it started on Linux  and I would have loved at that time to have the few instructions in the readme file.) Also, I have python 3.9 on my machine and LucasChess works very well. I'm suggesting in the readme to tell the audience that later python versions shall work - even if the main support and development in on 3.7. This could attract more potential users. 